### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: go install mvdan.cc/garble@latest
 
       - name: Get version tag
-        id: vars
+        id: get_version
         run: echo "VERSION_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Build binary
@@ -51,48 +51,48 @@ jobs:
       - name: Download build artifacts for linux-amd64
         uses: actions/download-artifact@v3
         with:
-          name: git-secrets-replacer-linux-amd64-${{ env.VERSION_TAG }}
+          name: git-secrets-replacer-linux-amd64-${{ needs.build.outputs.VERSION_TAG }}
           path: dist
 
       - name: Download build artifacts for linux-arm64
         uses: actions/download-artifact@v3
         with:
-          name: git-secrets-replacer-linux-arm64-${{ env.VERSION_TAG }}
+          name: git-secrets-replacer-linux-arm64-${{ needs.build.outputs.VERSION_TAG }}
           path: dist
 
       - name: Download build artifacts for darwin-amd64
         uses: actions/download-artifact@v3
         with:
-          name: git-secrets-replacer-darwin-amd64-${{ env.VERSION_TAG }}
+          name: git-secrets-replacer-darwin-amd64-${{ needs.build.outputs.VERSION_TAG }}
           path: dist
 
       - name: Download build artifacts for darwin-arm64
         uses: actions/download-artifact@v3
         with:
-          name: git-secrets-replacer-darwin-arm64-${{ env.VERSION_TAG }}
+          name: git-secrets-replacer-darwin-arm64-${{ needs.build.outputs.VERSION_TAG }}
           path: dist
 
       - name: Download build artifacts for windows-amd64
         uses: actions/download-artifact@v3
         with:
-          name: git-secrets-replacer-windows-amd64-${{ env.VERSION_TAG }}
+          name: git-secrets-replacer-windows-amd64-${{ needs.build.outputs.VERSION_TAG }}
           path: dist
 
       - name: Download build artifacts for windows-arm64
         uses: actions/download-artifact@v3
         with:
-          name: git-secrets-replacer-windows-arm64-${{ env.VERSION_TAG }}
+          name: git-secrets-replacer-windows-arm64-${{ needs.build.outputs.VERSION_TAG }}
           path: dist
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            dist/git-secrets-replacer-linux-amd64-${{ env.VERSION_TAG }}
-            dist/git-secrets-replacer-linux-arm64-${{ env.VERSION_TAG }}
-            dist/git-secrets-replacer-darwin-amd64-${{ env.VERSION_TAG }}
-            dist/git-secrets-replacer-darwin-arm64-${{ env.VERSION_TAG }}
-            dist/git-secrets-replacer-windows-amd64-${{ env.VERSION_TAG }}.exe
-            dist/git-secrets-replacer-windows-arm64-${{ env.VERSION_TAG }}.exe
+            dist/git-secrets-replacer-linux-amd64-${{ needs.build.outputs.VERSION_TAG }}
+            dist/git-secrets-replacer-linux-arm64-${{ needs.build.outputs.VERSION_TAG }}
+            dist/git-secrets-replacer-darwin-amd64-${{ needs.build.outputs.VERSION_TAG }}
+            dist/git-secrets-replacer-darwin-arm64-${{ needs.build.outputs.VERSION_TAG }}
+            dist/git-secrets-replacer-windows-amd64-${{ needs.build.outputs.VERSION_TAG }}.exe
+            dist/git-secrets-replacer-windows-arm64-${{ needs.build.outputs.VERSION_TAG }}.exe
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
Release was unable to obtain version tag identified in builds.

Updated the "needs" on release and ensured to pass the tag variable as an output on build.