### PR TITLE
Bug Fix - Secrets Regex

### DIFF
--- a/internal/replacer/processing.go
+++ b/internal/replacer/processing.go
@@ -156,7 +156,8 @@ func ProcessBlobWithGoroutines(sha, path string, secrets []string) (string, erro
 		go func() {
 			defer wg.Done()
 			for secret := range jobs {
-				regex := regexp.MustCompile(secret)
+				escapedRegex := regexp.QuoteMeta(secret)
+				regex := regexp.MustCompile(escapedRegex)
 				if regex.Match(output) {
 					mu.Lock()
 					content = regex.ReplaceAllString(content, "**REMOVED**")


### PR DESCRIPTION
Secrets with escape characters were not being processed appropriately. Escaped secrets with regexp.QuoteMeta() before processing the search and replace.