### PR TITLE
Processing Speed and Secret Sort Added

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           go-version: 1.22.6
 
-      - name: Install garble
-        run: go install mvdan.cc/garble@latest
-
       - name: Get version tag
         id: get_version
         run: echo "VERSION_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
@@ -35,7 +32,7 @@ jobs:
           mkdir -p dist
           suffix=""
           if [ "${{ matrix.goos }}" == "windows" ]; then suffix=".exe"; fi
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} garble -tiny build -o dist/git-secrets-replacer-${{ matrix.goos }}-${{ matrix.goarch }}-${{ env.VERSION_TAG }}${suffix}
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o dist/git-secrets-replacer-${{ matrix.goos }}-${{ matrix.goarch }}-${{ env.VERSION_TAG }}${suffix}
 
       - name: Create Linux zip file
         if: matrix.goos == 'linux'
@@ -47,6 +44,13 @@ jobs:
           EOL
           chmod +x dist/terminal.sh
           zip -j "dist/git-secrets-replacer-linux-${{ matrix.goarch }}-${{ env.VERSION_TAG }}.zip" "dist/git-secrets-replacer-linux-${{ matrix.goarch }}-${{ env.VERSION_TAG }}" "dist/terminal.sh"
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          for file in *; do
+            sha256sum "$file" > "$file.sha256"
+          done
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
@@ -99,5 +103,6 @@ jobs:
             dist/git-secrets-replacer-linux-arm64-${{ env.VERSION_TAG }}.zip
             dist/git-secrets-replacer-windows-amd64-${{ env.VERSION_TAG }}.exe
             dist/git-secrets-replacer-windows-arm64-${{ env.VERSION_TAG }}.exe
+            dist/*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/internal/replacer/processing_test.go
+++ b/internal/replacer/processing_test.go
@@ -1,0 +1,139 @@
+package replacer
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestProcessTree(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gitrepo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := exec.Command("git", "init", tmpDir).Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := "testfile.txt"
+	content := []byte("this is a secret\n")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "add", filePath).Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "commit", "-m", "initial commit").Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	commitHash, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitHashStr := strings.TrimSpace(string(commitHash))
+
+	treeHash, err := GetTree(commitHashStr)
+	if err != nil {
+		t.Fatalf("GetTree() error = %v", err)
+	}
+
+	secrets := []string{"secret"}
+
+	newTree, err := ProcessTree(treeHash, secrets)
+	if err != nil {
+		t.Fatalf("ProcessTree() error = %v", err)
+	}
+
+	if newTree == treeHash {
+		t.Fatalf("expected new tree to be different from the original tree")
+	}
+
+	newBlobHash, err := exec.Command("git", "cat-file", "-p", newTree).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newBlobContent, err := exec.Command("git", "cat-file", "-p", strings.Fields(string(newBlobHash))[2]).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedContent := "this is a **REMOVED**\n"
+	if string(newBlobContent) != expectedContent {
+		t.Errorf("expected blob content %q, got %q", expectedContent, string(newBlobContent))
+	}
+}
+
+func TestProcessCommitOrder(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gitrepo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := exec.Command("git", "init", tmpDir).Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := "testfile.txt"
+	content := []byte("this is a secret\n")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "add", filePath).Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "commit", "-m", "initial commit").Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	content = []byte("this is another secret\n")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "add", filePath).Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "commit", "-m", "second commit").Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	commitHashes, err := exec.Command("git", "rev-list", "--all").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitHashList := strings.Split(strings.TrimSpace(string(commitHashes)), "\n")
+
+	secrets := []string{"secret"}
+
+	var newCommitHashes []string
+	for _, commitHash := range commitHashList {
+		newCommitHash, err := ProcessCommit(commitHash, secrets)
+		if err != nil {
+			t.Fatalf("ProcessCommit() error = %v", err)
+		}
+		newCommitHashes = append(newCommitHashes, newCommitHash)
+	}
+
+	if len(newCommitHashes) != len(commitHashList) {
+		t.Fatalf("expected %d commits, got %d", len(commitHashList), len(newCommitHashes))
+	}
+
+	for i, newCommitHash := range newCommitHashes {
+		if newCommitHash == commitHashList[i] {
+			t.Fatalf("expected new commit hash to be different from the original commit hash")
+		}
+	}
+}

--- a/internal/replacer/utils.go
+++ b/internal/replacer/utils.go
@@ -3,6 +3,7 @@ package replacer
 import (
 	"bufio"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -25,6 +26,10 @@ func ReadSecrets(filePath string) ([]string, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
+
+	sort.Slice(secrets, func(i, j int) bool {
+		return len(secrets[i]) > len(secrets[j])
+	})
 
 	return secrets, nil
 }

--- a/internal/replacer/utils_test.go
+++ b/internal/replacer/utils_test.go
@@ -1,0 +1,68 @@
+package replacer
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadSecrets(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "secrets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	content := []byte("secret1\nsecret2\nsecret3\n")
+	if _, err := tmpfile.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	secrets, err := ReadSecrets(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("ReadSecrets() error = %v", err)
+	}
+
+	expected := []string{"secret1", "secret2", "secret3"}
+	if len(secrets) != len(expected) {
+		t.Fatalf("expected %d secrets, got %d", len(expected), len(secrets))
+	}
+	for i, secret := range secrets {
+		if secret != expected[i] {
+			t.Errorf("expected secret %q, got %q", expected[i], secret)
+		}
+	}
+}
+
+func TestReadSecretsSorted(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "secrets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	content := []byte("short\nmediumlength\nveryverylongsecret\n")
+	if _, err := tmpfile.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	secrets, err := ReadSecrets(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("ReadSecrets() error = %v", err)
+	}
+
+	expected := []string{"veryverylongsecret", "mediumlength", "short"}
+	if len(secrets) != len(expected) {
+		t.Fatalf("expected %d secrets, got %d", len(expected), len(secrets))
+	}
+	for i, secret := range secrets {
+		if secret != expected[i] {
+			t.Errorf("expected secret %q, got %q", expected[i], secret)
+		}
+	}
+}


### PR DESCRIPTION
Secrets were updated to be sorted and processed from largest to smallest, this should avoid issues where a smaller secrets was contained in a larger secret and was being removed first causing the larger secret to not be removed.

Updated the processing code to increase overall speed.

Added tests for both processing.go and utils.go.

Updated GitHub Actions to remove Garble and include cheksums for the files.