### PR TITLE
Updated Cosign Workflow action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Sign artifacts with Cosign
         run: |
           for file in dist/*; do
-            cosign sign-blob --keyless $file
+            cosign sign-blob $file
           done
 
       - name: Generate SLSA Provenance


### PR DESCRIPTION
Removed --keyless flag in sigstore/cosign as this flag is no longer needed and is implemented as a default if no key provided.